### PR TITLE
chore: rename GitHub workflow for `test`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Node CI
+name: test
 
 # only run on pull requests targeting `master` branch
 on:


### PR DESCRIPTION
Just a simple name & filename change of the workflow file, so the right name of the workflow is shown in the actions menu (rather than NodeCI)