### PR TITLE
fix: do not `throw` when rule id cannot be obtained from url

### DIFF
--- a/src/utils/get-rule-id.test.ts
+++ b/src/utils/get-rule-id.test.ts
@@ -8,27 +8,27 @@ describe('ruleIdFromUri', () => {
 
   it('throws if the rule ID is too short', () => {
     const uri = '/59a7/55f3ed0ec0f324514a0d223b737bc1e4c81593c7.html'
-    expect(() => ruleIdFromUri(uri)).toThrow()
+    expect(ruleIdFromUri(uri)).toBeUndefined()
   })
 
   it('throws if the rule ID is too long', () => {
     const uri = '/5f99a73sd/55f3ed0ec0f324514a0d223b737bc1e4c81593c7.html'
-    expect(() => ruleIdFromUri(uri)).toThrow()
+    expect(ruleIdFromUri(uri)).toBeUndefined()
   })
 
   it('throws if the testcase ID is too short', () => {
     const uri = '/5f99a7/55f3ed0ec0f324514a0d223b737bc1e4c81593c.html'
-    expect(() => ruleIdFromUri(uri)).toThrow()
+    expect(ruleIdFromUri(uri)).toBeUndefined()
   })
 
   it('throws if the testcase ID is too long', () => {
     const uri = '/5f99a7/55f3ed0ec0f324514a0d223b737bc1e4c81593c77.html'
-    expect(() => ruleIdFromUri(uri)).toThrow()
+    expect(ruleIdFromUri(uri)).toBeUndefined()
   })
 
   it('throws if there is no extension', () => {
     const uri = '/5f99a7/55f3ed0ec0f324514a0d223b737bc1e4c81593c7.'
-    expect(() => ruleIdFromUri(uri)).toThrow()
+    expect(ruleIdFromUri(uri)).toBeUndefined()
   })
 })
 
@@ -52,11 +52,11 @@ describe('ruleIdFromSubject', () => {
   })
 
   it('throws if the URI has no rule ID', () => {
-    expect(() =>
+    expect(
       ruleIdFromSubject({
         '@type': 'earl:TestSubject',
         source: 'foobar',
       })
-    ).toThrow()
+    ).toBeUndefined()
   })
 })

--- a/src/utils/get-rule-id.ts
+++ b/src/utils/get-rule-id.ts
@@ -1,5 +1,6 @@
 import { EarlTestSubject } from '../earl/types'
 import { sourceFromSubject } from './get-source'
+import debug from 'debug'
 
 export function ruleIdFromSubject(subject: EarlTestSubject | string): string | void {
   const source = sourceFromSubject(subject)
@@ -8,10 +9,11 @@ export function ruleIdFromSubject(subject: EarlTestSubject | string): string | v
   }
 }
 
-export function ruleIdFromUri(url: string): string {
+export function ruleIdFromUri(url: string): string | undefined {
   const match = url.match(/\/([a-z0-9]{6})\/([a-z0-9]{40})\.[a-z]{2,4}/)
   if (!match) {
-    throw new Error(`Unable to find rule ID in ${url}`)
+    debug('ruleIdFromUri')(`Unable to find rule ID in ${url}`)
+    return undefined
   }
   return match[1]
 }


### PR DESCRIPTION
> The change is here - https://github.com/act-rules/act-rules-implementation-mapper/pull/20/files#diff-0903f1ffd0e2bf6407733725a3d0ef9cR16, other changes are changes to tests.

Throwing is unnecessary when the rule id cannot be interpreted from a given source/ url.

The mapper simply [ignores](https://github.com/act-rules/act-rules-implementation-mapper/blob/master/src/act-map-generator.ts#L49)  a given assertion, if ruleId cannot be obtained from a test source.

There are some reports which have URL's like so - https://github.com/act-rules/act-rules-implementation-qualweb/blob/master/reports/qualweb-bc659a.json#L43, which breaks mapper execution if it throws. Instead it should be logged to enable debugging further.


