### PR TITLE
chore: add build trigger of ACT website from repo

### DIFF
--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -1,0 +1,17 @@
+# Send a build trigger to `act-rules-web` repository, everytime something is merged to master
+name: dispatch
+
+on:
+  push:
+    branches:
+      - chore-trigger-build
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v1
+      - shell: bash
+        name: send 'repository_dispatch' trigger to ACT W repository
+        run: |
+          curl -XPOST -u "${{ secrets.USER_NAME }}:${{ secrets.USER_PAT }}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/act-rules/act-rules-web/dispatches --data '{ "event_type": "build_application" }'

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -4,7 +4,7 @@ name: dispatch
 on:
   push:
     branches:
-      - chore-trigger-build
+      - master
 
 jobs:
   dispatch:


### PR DESCRIPTION
It makes sense to rebuild the ACT Rules website when a change lands here.