### PR TITLE
fix: `@types/node` version

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "prettier": "npm run prettier:write",
     "prettier:base": "prettier --parser typescript --single-quote",
     "prettier:check": "npm run prettier:base -- --list-different \"src/**/*.ts\"",
-    "prettier:write": "npm run prettier:base -- --write \"src/**/*.ts\""
+    "prettier:write": "npm run prettier:base -- --write \"src/**/*.ts\"",
+    "tmp": "node index.js"
   },
   "repository": {
     "type": "git",
@@ -34,7 +35,7 @@
     "@types/debug": "^4.1.5",
     "@types/jest": "24.0.0",
     "@types/jsonld": "^1.5.0",
-    "@types/node": "*",
+    "@types/node": ">=4.2.0 < 13",
     "@types/request-promise": "^4.1.44",
     "@types/yargs": "^13.0.3",
     "debug": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "prettier": "npm run prettier:write",
     "prettier:base": "prettier --parser typescript --single-quote",
     "prettier:check": "npm run prettier:base -- --list-different \"src/**/*.ts\"",
-    "prettier:write": "npm run prettier:base -- --write \"src/**/*.ts\"",
-    "tmp": "node index.js"
+    "prettier:write": "npm run prettier:base -- --write \"src/**/*.ts\""
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The CI on this PR is failing - https://github.com/act-rules/act-rules-web/pull/203.
Because of the below error:

```js
../jest-haste-map/build/index.d.ts:125:32 - error TS2507: Type 'typeof EventEmitter' is not a constructor function type.
```

Apparently this is due to a breaking change as [described here](https://github.com/slackapi/node-slack-sdk/issues/951#issuecomment-603602844)

Specifying specifying 12 in package.json will sort it out.